### PR TITLE
Set container=docker for Kaniko v1.8.0

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -58,6 +58,10 @@ export const generateArgs = (inputs: Inputs, outputDir: string): string[] => {
     `${outputDir}:/kaniko/action/output`,
     '-v',
     `${os.homedir()}/.docker/config.json:/kaniko/.docker/config.json:ro`,
+    // workaround for kaniko v1.8.0+
+    // https://github.com/GoogleContainerTools/kaniko/issues/1542#issuecomment-1066028047
+    '-e',
+    'container=docker',
     inputs.executor,
     // kaniko args
     '--context',

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -31,6 +31,8 @@ test('default args', () => {
     `/tmp/kaniko-action:/kaniko/action/output`,
     '-v',
     `${os.homedir()}/.docker/config.json:/kaniko/.docker/config.json:ro`,
+    '-e',
+    'container=docker',
     'gcr.io/kaniko-project/executor:latest',
     // kaniko args
     '--context',
@@ -72,6 +74,8 @@ test('full args', () => {
     `/tmp/kaniko-action:/kaniko/action/output`,
     '-v',
     `${os.homedir()}/.docker/config.json:/kaniko/.docker/config.json:ro`,
+    '-e',
+    'container=docker',
     'gcr.io/kaniko-project/executor:latest',
     // kaniko args
     '--context',
@@ -131,6 +135,8 @@ test('with dockerfile', () => {
     `/tmp/kaniko-action:/kaniko/action/output`,
     '-v',
     `${os.homedir()}/.docker/config.json:/kaniko/.docker/config.json:ro`,
+    '-e',
+    'container=docker',
     'gcr.io/kaniko-project/executor:latest',
     // kaniko args
     '--context',


### PR DESCRIPTION
Since Kaniko v1.8.0, it raises the following error when a container runs on GitHub Actions.

>  kaniko should only be run inside of a container, run with the --force flag if you are sure you want to continue
> https://github.com/int128/kaniko-action/runs/5519183807?check_suite_focus=true
> https://github.com/int128/kaniko-action/pull/106/commits/1bfb73829f540b91a349fc84d1b06c2bba4984c4

I found the workaround at https://github.com/GoogleContainerTools/kaniko/issues/1542#issuecomment-1066028047. This PR will add it. I tested it at https://github.com/int128/kaniko-action/pull/106/commits/3a23d789a7abed731eb4e7e476c593fdbd016d29.