### PR TITLE
fix docker config folder volume

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -57,7 +57,7 @@ export const generateArgs = (inputs: Inputs, outputDir: string): string[] => {
     '-v',
     `${outputDir}:/kaniko/action/output`,
     '-v',
-    `${os.homedir()}/.docker/config.json:/kaniko/.docker/config.json:ro`,
+    `${os.homedir()}/.docker/:/kaniko/.docker/:ro`,
     // workaround for kaniko v1.8.0+
     // https://github.com/GoogleContainerTools/kaniko/issues/1542#issuecomment-1066028047
     '-e',


### PR DESCRIPTION
Fixes #84 
Fixes #128 

Mount the entire `.docker` folder instead the `config.json` file.
These fixes the error below.

```
read /kaniko/.docker/config.json: is a directory
```

Tested on the same repository where I had the initial error using my fixed action: https://github.com/marketplace/actions/kaniko-action-fork