### PR TITLE
Add input for mounting extra files into /kaniko

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ See also the flags of [Kaniko executor](https://github.com/GoogleContainerTools/
 |------|-------------|-------------------
 | `executor` | Image of Kaniko executor. Default to `gcr.io/kaniko-project/executor:v1.23.0` | -
 | `context` <sup>*1</sup> | Path to the build context. Default to the workspace | -
+| `extra-context` | List of id=path for extra files to mount into kaniko under /kaniko/action/extra-context/:id. Useful for providing secrets to the build | -
 | `file` <sup>*1</sup> | Path to the Dockerfile. Default to `Dockerfile`. It must be in the context. If set, this action passes the relative path to Kaniko, same as the behavior of [`docker build`](https://docs.docker.com/engine/reference/commandline/build/) | `--dockerfile`
 | `build-args` <sup>*1</sup> | List of build args | `--build-arg`
 | `labels` <sup>*1</sup> | List of metadata for an image | `--label`
@@ -102,7 +103,7 @@ See also the flags of [Kaniko executor](https://github.com/GoogleContainerTools/
 ### Cache layers
 
 Kaniko supports the layer caching with a remote repository such as GHCR or Amazon ECR.
-See https://github.com/GoogleContainerTools/kaniko#caching for details.
+See <https://github.com/GoogleContainerTools/kaniko#caching> for details.
 
 To enable the layer caching, set a cache repository.
 
@@ -116,7 +117,7 @@ To enable the layer caching, set a cache repository.
 ### Build a multi-architecture image
 
 We can build a multi-architecture image such as `amd64` and `arm64` on self-hosted runners in GitHub Actions.
-See also https://github.com/int128/docker-manifest-create-action.
+See also <https://github.com/int128/docker-manifest-create-action>.
 
 Here is an example stack to build an `arm64` image.
 

--- a/action.yaml
+++ b/action.yaml
@@ -28,7 +28,9 @@ inputs:
   kaniko-args:
     description: Extra args to Kaniko executor
     required: false
-
+  extra-context:
+    description: Content to mount under /kaniko/extra
+    required: false
   # compatible with https://github.com/docker/build-push-action
   build-args:
     description: List of build args

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ const main = async (): Promise<void> => {
     push: core.getBooleanInput('push'),
     tags: core.getMultilineInput('tags'),
     target: core.getInput('target'),
+    extraContext: core.getMultilineInput("extra-context")
   })
   core.setOutput('digest', outputs.digest)
 }

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -17,6 +17,7 @@ const defaultInputs = {
   push: false,
   tags: [],
   target: '',
+  extraContext: []
 }
 
 test('default args', () => {
@@ -61,6 +62,7 @@ test('full args', () => {
       push: false,
       tags: ['helloworld:latest', 'ghcr.io/int128/kaniko-action/example:v1.0.0'],
       target: 'server',
+      extraContext: ['npmrc=/tmp/npmrc-5ab']
     },
     '/tmp/kaniko-action',
   )
@@ -76,6 +78,8 @@ test('full args', () => {
     `${os.homedir()}/.docker/:/kaniko/.docker/:ro`,
     '-e',
     'container=docker',
+    '-v',
+    '/tmp/npmrc-5ab:/kaniko/action/extra-context/npmrc:ro',
     'gcr.io/kaniko-project/executor:latest',
     // kaniko args
     '--context',


### PR DESCRIPTION
This mounts individual files given by id=path pairs under `/kaniko/action/extra-context/:id` as `ro`

Allows the workaround for providing secrets to kaniko builds described in https://tobiasmaier.info/posts/2022/11/01/kaniko.html.
